### PR TITLE
Move keyboard and mouse variables into their main C files instead of being declared in header files

### DIFF
--- a/cu_kbd.c
+++ b/cu_kbd.c
@@ -29,6 +29,19 @@
 #include "cu_kbd.h"
 #include "cu_mouse.h"
 
+auint cu_kbd_state;
+auint cu_kbd_clock;
+auint cu_kbd_data_in;
+auint cu_kbd_data_out;
+auint cu_kbd_enabled;
+auint cu_kbd_bypassed; /* don't check for start condition, allows user to break out of keyboard passthrough mode and use emulator controls */
+
+auint cu_kbd_queue_in;
+auint cu_kbd_queue_out;
+uint8 cu_kbd_queue[512];
+
+auint cu_kbd_held_lctrl;
+
 
 /* Scan codes */
 const auint cu_kbd_scan_codes[][2] = {
@@ -245,4 +258,3 @@ auint  cu_kbd_get_enabled(void){
 void cu_kbd_set_enabled(uint8 val){
  cu_kbd_enabled = val;
 }
-

--- a/cu_kbd.h
+++ b/cu_kbd.h
@@ -30,18 +30,18 @@
 
 #include "types.h"
 
-auint cu_kbd_state;
-auint cu_kbd_clock;
-auint cu_kbd_data_in;
-auint cu_kbd_data_out;
-auint cu_kbd_enabled;
-auint cu_kbd_bypassed; /* don't check for start condition, allows user to break out of keyboard passthrough mode and use emulator controls */
+extern auint cu_kbd_state;
+extern auint cu_kbd_clock;
+extern auint cu_kbd_data_in;
+extern auint cu_kbd_data_out;
+extern auint cu_kbd_enabled;
+extern auint cu_kbd_bypassed; /* don't check for start condition, allows user to break out of keyboard passthrough mode and use emulator controls */
 
-auint cu_kbd_queue_in;
-auint cu_kbd_queue_out;
-uint8 cu_kbd_queue[512];
+extern auint cu_kbd_queue_in;
+extern auint cu_kbd_queue_out;
+extern uint8 cu_kbd_queue[512];
 
-auint cu_kbd_held_lctrl;
+extern auint cu_kbd_held_lctrl;
 
 
 /* Keyboard Dongle defines */

--- a/cu_mouse.c
+++ b/cu_mouse.c
@@ -28,6 +28,11 @@
 
 #include "cu_mouse.h"
 
+uint8 cu_mouse_enabled;
+sint32 cu_mouse_dx, cu_mouse_dy;
+uint8 cu_mouse_buttons;
+uint8 cu_mouse_scale;
+
 void cu_adjust_mouse_scale(){ /* TODO replace the implementation in main.c, */
 /* TODO have keyboard ctrl+alt+m toggle mouse sensitivity */
      cu_mouse_scale++;

--- a/cu_mouse.h
+++ b/cu_mouse.h
@@ -30,10 +30,10 @@
 
 #include "types.h"
 
-uint8 cu_mouse_enabled;
-sint32 cu_mouse_dx, cu_mouse_dy;
-uint8 cu_mouse_buttons;
-uint8 cu_mouse_scale;
+extern uint8 cu_mouse_enabled;
+extern sint32 cu_mouse_dx, cu_mouse_dy;
+extern uint8 cu_mouse_buttons;
+extern uint8 cu_mouse_scale;
 
 void cu_adjust_mouse_scale();
 


### PR DESCRIPTION
Fixes issue #1.