### PR TITLE
Fix compilation with GCC 15

### DIFF
--- a/Make_defines.mk
+++ b/Make_defines.mk
@@ -33,7 +33,7 @@
 #
 #
 include Make_config.mk
-CFLAGS=
+CFLAGS=-std=gnu17
 #
 #
 # The compiler


### PR DESCRIPTION
GCC 15 defaults to the C23 standard + GNU extensions which causes compilation errors here. This patch works around that by forcing the use of C17 + GNU extensions with `-std=gnu17`. It would be good to test this with older versions of GCC first before merging this, like GCC 12 which is what Debian 12 seems to use by default.